### PR TITLE
Fixed doc_type check

### DIFF
--- a/elasticmock/fake_elasticsearch.py
+++ b/elasticmock/fake_elasticsearch.py
@@ -156,7 +156,7 @@ class FakeElasticsearch(Elasticsearch):
         matches = []
         for searchable_index in searchable_indexes:
             for document in self.__documents_dict[searchable_index]:
-                if doc_type is not None and document.get('_type') != doc_type:
+                if doc_type is not None and document.get('_type') not in doc_type:  # value in a list of allowed doc_types
                     continue
                 matches.append(document)
 


### PR DESCRIPTION
doc_type to `search` method is list, while `document['_type']` is a string.